### PR TITLE
Added a feature to allow no death run

### DIFF
--- a/RandomizerCommon/EldenForm.Designer.cs
+++ b/RandomizerCommon/EldenForm.Designer.cs
@@ -128,6 +128,7 @@
             this.nerfmalenia = new System.Windows.Forms.CheckBox();
             this.allmaps = new System.Windows.Forms.CheckBox();
             this.extraRandomGroup = new System.Windows.Forms.GroupBox();
+            this.nodeathvalid = new System.Windows.Forms.CheckBox();
             this.invertgestures = new System.Windows.Forms.CheckBox();
             this.invertenvbgm = new System.Windows.Forms.CheckBox();
             this.invertoutfits = new System.Windows.Forms.CheckBox();
@@ -1358,6 +1359,7 @@
             // 
             // extraRandomGroup
             // 
+            this.extraRandomGroup.Controls.Add(this.nodeathvalid);
             this.extraRandomGroup.Controls.Add(this.invertgestures);
             this.extraRandomGroup.Controls.Add(this.invertenvbgm);
             this.extraRandomGroup.Controls.Add(this.invertoutfits);
@@ -1372,6 +1374,19 @@
             this.extraRandomGroup.TabIndex = 0;
             this.extraRandomGroup.TabStop = false;
             this.extraRandomGroup.Text = "Additional randomization";
+            // 
+            // nodeathvalid
+            // 
+            this.nodeathvalid.AutoSize = true;
+            this.nodeathvalid.Checked = true;
+            this.nodeathvalid.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.nodeathvalid.Location = new System.Drawing.Point(6, 161);
+            this.nodeathvalid.Name = "nodeathvalid";
+            this.nodeathvalid.Size = new System.Drawing.Size(150, 20);
+            this.nodeathvalid.TabIndex = 7;
+            this.nodeathvalid.Text = "Make sure the run can be done deathless";
+            this.nodeathvalid.UseVisualStyleBackColor = true;
+            this.nodeathvalid.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
             // 
             // invertgestures
             // 
@@ -1822,6 +1837,7 @@
         private System.Windows.Forms.CheckBox invertgestures;
         private System.Windows.Forms.CheckBox invertenvbgm;
         private System.Windows.Forms.CheckBox invertoutfits;
+        private System.Windows.Forms.CheckBox nodeathvalid;
     }
 }
 

--- a/RandomizerCommon/KeyItemsPermutation.cs
+++ b/RandomizerCommon/KeyItemsPermutation.cs
@@ -82,6 +82,24 @@ namespace RandomizerCommon
                     }
                 }
 
+                //If noDeath guaranteed, set the drawingroomkey forced requirements
+                if (options["nodeathvalid"])
+                {
+                    configExprs["drawingroomkeyreq"] = Expr.Named("volcano_drawingroom");
+                }
+                else
+                {
+                    //"volcano_drawingroom OR (academy AND altus);
+                    configExprs["drawingroomkeyreq"] =
+                        new Expr(
+                            new List<Expr>(){
+                                Expr.Named("volcano_drawingroom"),
+                                new Expr(
+                                    new List<Expr>(){
+                                        Expr.Named("academy"),
+                                        Expr.Named("altus") }) }, false);
+                }
+
                 // If leyndellRunes is 0, this condition just becomes true
                 configExprs["runes_leyndell"] = new Expr(runes.Take(leyndellRunes).Select(r => Expr.Named(r)).ToList(), true);
                 if (roldRunes == -1)

--- a/diste/Base/annotations.txt
+++ b/diste/Base/annotations.txt
@@ -597,7 +597,8 @@ Areas:
 - Name: volcano_town
   Text: Volcano Manor
   # Add 'altus' condition so that Dectus medallion isn't placed here
-  Req: volcano_drawingroom OR (academy AND altus)
+  # Old was : volcano_drawingroom OR (academy AND altus)
+  Req: drawingroomkeyreq
   Maps: m16_00_00_00
   MainMaps: m16_00_00_00
 - Name: volcano_temple

--- a/diste/Messages/de.json
+++ b/diste/Messages/de.json
@@ -579,6 +579,12 @@
       "text": "Mini-Dungeons von allen obigen Orten ausschließen"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/es-ES.json
+++ b/diste/Messages/es-ES.json
@@ -538,6 +538,12 @@
       "text": ""
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/es.json
+++ b/diste/Messages/es.json
@@ -561,6 +561,12 @@
       "text": "Excluye a las mazmorras de todos los lugares anteriores"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/fr.json
+++ b/diste/Messages/fr.json
@@ -591,6 +591,12 @@
       "text": "Retire les mini-donjons de tous les emplacements au dessus"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": "Assurer que le jeu puisse être complété sans mourir"
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/it.json
+++ b/diste/Messages/it.json
@@ -537,6 +537,12 @@
       "text": ""
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/ja.json
+++ b/diste/Messages/ja.json
@@ -567,6 +567,12 @@
       "text": "上記すべての場所からミニダンジョンを除外"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/kk-KZ.json
+++ b/diste/Messages/kk-KZ.json
@@ -538,6 +538,12 @@
       "text": "[[Exclude mini-dungeons from all of the above locations]]"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/ko.json
+++ b/diste/Messages/ko.json
@@ -537,6 +537,12 @@
       "text": ""
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/pl.json
+++ b/diste/Messages/pl.json
@@ -561,6 +561,12 @@
       "text": "Przedmioty kluczowe nie mogą się pojawiać w tych lokacjach"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/pt-BR.json
+++ b/diste/Messages/pt-BR.json
@@ -543,6 +543,12 @@
       "text": "Excluir mini-dungeons de todos os locais acima"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/ru.json
+++ b/diste/Messages/ru.json
@@ -561,6 +561,12 @@
       "text": "Исключить подземелья из выше упомянутого списка локаций"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/th.json
+++ b/diste/Messages/th.json
@@ -537,6 +537,12 @@
       "text": ""
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",

--- a/diste/Messages/zh.json
+++ b/diste/Messages/zh.json
@@ -579,6 +579,12 @@
       "text": "在上述位置中排除小型箱庭"
     },
     {
+      "name": "EldenForm_nodeathvalid",
+      "explanation": "Button to force the randomizer to allow a no death run, making sur the drawing room key isn't inaccessible",
+      "english_text": "Make sure the run can be done deathless",
+      "text": ""
+    },
+    {
       "name": "EldenForm_nohand",
       "explanation": "Radio button for starting class randomization: if chosen, all starting class stat requirements are completely ignored, and the player may start with a weapon or spell they do not have the stats to use",
       "english_text": "Allow unwieldable weapon and spells",


### PR DESCRIPTION
Added an option to force a no death run compatibility. This forces the drawing room key to be accessible without death (so not counting the academy as a valid way to go to the volcano manor)


For information, there are a lot of people (including me) who does all bosses no death runs.
With the current settings of the randomizer it's possible to be locked out of it having the drawing room key in the volcano manor. Which forces you to die in the academy to be able to defeat all the bosses.

Hence the feature to add an option for the randomizer to force the drawing room key to be available.